### PR TITLE
test: Stabilize failing e2e cypress test (#17252)

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product_configurator/product-configurator-vc-ov-filter-menu-e2e-spec-flaky.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product_configurator/product-configurator-vc-ov-filter-menu-e2e-spec-flaky.cy.ts
@@ -38,6 +38,7 @@ context('Product Configuration', () => {
   });
 
   it('should be able filter the overview page', () => {
+    cy.viewport(1000, 660);
     clickAllowAllFromBanner();
     completeDigitalCameraConfiguration();
     configuration.navigateToOverviewPage();


### PR DESCRIPTION
Before running an e2e test, set a viewport width and height.

Closes CXSPA-3069