### PR TITLE
test(ssr): test NgExpressEngineDecorator when custom options are not …

### DIFF
--- a/core-libs/setup/ssr/engine-decorator/ng-express-engine-decorator.spec.ts
+++ b/core-libs/setup/ssr/engine-decorator/ng-express-engine-decorator.spec.ts
@@ -238,4 +238,72 @@ describe('decorateExpressEngine', () => {
       expect(originalEngineInstance).toHaveBeenCalledTimes(3);
     });
   });
+
+  describe('with optimizations not specified on 2nd argument', () => {
+    beforeEach(() => {
+      const engine = decorateExpressEngine(
+        originalEngine
+        // 2nd argument not specified (but not explicitly "undefined"!)
+      );
+      engineInstance = engine(mockEngineOptions);
+      engineInstance(mockPath, mockOptions, mockCallback);
+    });
+
+    it(`should pass parameters to the original engine instance`, () => {
+      expect(originalEngineInstance).toHaveBeenCalledWith(
+        mockPath,
+        mockOptions,
+        expect.any(Function)
+      );
+    });
+
+    it(`should apply optimization wrapper`, () => {
+      // we check that callback is not the original one
+      expect(originalEngineInstance).not.toHaveBeenCalledWith(
+        mockPath,
+        mockOptions,
+        mockCallback
+      );
+    });
+
+    it(`should pass setup options to the original engine`, () => {
+      expect(originalEngine).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bootstrap: 'TestModule',
+          providers: expect.arrayContaining([
+            { provide: 'testToken', useValue: 'testValue' },
+          ]),
+        })
+      );
+    });
+
+    it(`should add SERVER_REQUEST_URL to providers in the setup options passed to the original engine`, () => {
+      expect(originalEngine).toHaveBeenCalledWith(
+        expect.objectContaining({
+          providers: expect.arrayContaining([
+            expect.objectContaining({
+              provide: SERVER_REQUEST_URL,
+            }),
+          ]),
+        })
+      );
+    });
+
+    it(`should be called only once per request with caching`, () => {
+      const mockOptions2 = {
+        ...mockOptions,
+        req: { ...mockOptions.req, originalUrl: 'aaa' },
+      };
+      const mockOptions3 = {
+        ...mockOptions,
+        req: { ...mockOptions.req, originalUrl: 'ccc' },
+      };
+      engineInstance(mockPath, mockOptions, mockCallback);
+      engineInstance('aaa', mockOptions2, mockCallback);
+      engineInstance(mockPath, mockOptions, mockCallback);
+      engineInstance('aaa', mockOptions2, mockCallback);
+      engineInstance('ccc', mockOptions3, mockCallback);
+      expect(originalEngineInstance).toHaveBeenCalledTimes(3);
+    });
+  });
 });


### PR DESCRIPTION
…specified at 2nd argument (#17271)

followup of https://github.com/SAP/spartacus/pull/17230 related to https://jira.tools.sap/browse/CXSPA-3053